### PR TITLE
Fixed Django 2.0 startup issues

### DIFF
--- a/publications_bootstrap/models/publication.py
+++ b/publications_bootstrap/models/publication.py
@@ -52,7 +52,7 @@ class Publication(models.Model):
         ACCEPTED = ('a', _('accepted'))
         PUBLISHED = ('p', _('published'))
 
-    type = models.ForeignKey(Type, db_index=True)
+    type = models.ForeignKey(Type, db_index=True, on_delete=models.PROTECT)
     citekey = NullCharField(max_length=512, blank=True, null=True, unique=True, db_index=True,
                             help_text='BibTex citation key. Leave blank if unsure.')
     title = models.CharField(max_length=512, db_index=True)

--- a/publications_bootstrap/models/publicationfile.py
+++ b/publications_bootstrap/models/publicationfile.py
@@ -9,7 +9,7 @@ class PublicationFile(models.Model):
     class Meta:
         app_label = 'publications_bootstrap'  # Fix for Django<1.7
 
-    publication = models.ForeignKey(Publication)
+    publication = models.ForeignKey(Publication, on_delete=models.CASCADE)
     description = models.CharField(max_length=256)
     file = models.FileField(upload_to='publications_bootstrap/')
 

--- a/publications_bootstrap/models/publicationlink.py
+++ b/publications_bootstrap/models/publicationlink.py
@@ -9,7 +9,7 @@ class PublicationLink(models.Model):
     class Meta:
         app_label = 'publications_bootstrap'  # Fix for Django<1.7
 
-    publication = models.ForeignKey(Publication)
+    publication = models.ForeignKey(Publication, on_delete=models.CASCADE)
     description = models.CharField(max_length=256)
     url = models.URLField(verbose_name='URL')
 

--- a/publications_bootstrap/tests/tests.py
+++ b/publications_bootstrap/tests/tests.py
@@ -4,13 +4,18 @@ from distutils.version import StrictVersion
 
 import django
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from django.http import HttpRequest
 from django.template import Template, RequestContext
 from django.test import TestCase
 
 from ..models import Publication, Type, PublicationLink, Catalog
 from ..templatetags.publication_extras import tex_parse
+
+
+try:
+    from django.urls import reverse  # Django 1.10+
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 warnings.simplefilter("always")
 


### PR DESCRIPTION
This PR fixes the most obvious Django 2.0 issues that cause errors before the app starts.

I haven't found a way to run the tests, so more errors could still be present before full Django 2.0 compatibility is fixed. For example, errors with `urlquote_plus()` no longer accepting strings is not fixed yet.