### PR TITLE
Two small bugfixes for the public views in Django 2.0

### DIFF
--- a/publications_bootstrap/models/publication.py
+++ b/publications_bootstrap/models/publication.py
@@ -355,7 +355,8 @@ class Publication(models.Model):
         if self.book_title and not self.journal:
             context_obj.append('rft_val_fmt=info:ofi/fmt:kev:mtx:book')
             context_obj.append('rfr_id=info:sid/' + domain + ':' + rfr_id)
-            context_obj.append('rft_id=info:doi/' + urlquote_plus(self.doi))
+            if self.doi:
+                context_obj.append('rft_id=info:doi/' + urlquote_plus(self.doi))
 
             context_obj.append('rft.btitle=' + urlquote_plus(self.title))
 
@@ -365,7 +366,8 @@ class Publication(models.Model):
         else:
             context_obj.append('rft_val_fmt=info:ofi/fmt:kev:mtx:journal')
             context_obj.append('rfr_id=info:sid/' + domain + ':' + rfr_id)
-            context_obj.append('rft_id=info:doi/' + urlquote_plus(self.doi))
+            if self.doi:
+                context_obj.append('rft_id=info:doi/' + urlquote_plus(self.doi))
             context_obj.append('rft.atitle=' + urlquote_plus(self.title))
 
             if self.journal:

--- a/publications_bootstrap/templates/publications_bootstrap/base.html
+++ b/publications_bootstrap/templates/publications_bootstrap/base.html
@@ -16,14 +16,16 @@
 
 {% block content %}
     <div class="pubo">
-        {% if publication or publications %}
-            {% include 'publications_bootstrap/components/download_all.html' %}
-            {% block pubo_content_page %}
-                {% include 'publications_bootstrap/components/section.html' %}
-            {% endblock pubo_content_page %}
-        {% else %}
-            {% include 'publications_bootstrap/components/empty.html' %}
-        {% endif %}
+        {% block app_content %}
+            {% if publication or publications %}
+                {% include 'publications_bootstrap/components/download_all.html' %}
+                {% block pubo_content_page %}
+                    {% include 'publications_bootstrap/components/section.html' %}
+                {% endblock pubo_content_page %}
+            {% else %}
+                {% include 'publications_bootstrap/components/empty.html' %}
+            {% endif %}
+        {% endblock %}
     </div>
 {% endblock content %}
 


### PR DESCRIPTION
I've briefly checked my project against Django 2.0, and these two small bugs stood out:

- doi could be `None`, which gives errors with `urlquote_plus()` in Django 2.0 which raises "quote_from_bytes() expected bytes"
- The `{% block app_content %}` was not included in the template.

From what I've seen in a quick look, everything else works fine in Django 2.0!