### PR TITLE
Fixed the README path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from publications_bootstrap import __version__
 
 REPO_URL = "https://github.com/mbourqui/django-publications-bootstrap/"
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
This is a simple fix to allow running setup.py through, for example, `pip install`. The name of the README file was changed at some point from `README.rst` to `README.md`, but `setup.py` was still looking for the `.rst` file.